### PR TITLE
Add Capability to Include HTTP Response Attributes in Audit Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ order = "9983"
 enable = true
 
 [[catalina.valves]]
-properties.className = "org.sample.custom.tomcat.valve.RequestDataExtractorValve"
+properties.className = "org.sample.custom.tomcat.valve.CustomAuditLoggerValve"
 ```
 
 Add the below to the `<IS_HOME>/repository/conf/log4j2.properties` file:

--- a/src/main/java/org/sample/custom/audit/logger/CustomAuditLogger.java
+++ b/src/main/java/org/sample/custom/audit/logger/CustomAuditLogger.java
@@ -2,10 +2,10 @@ package org.sample.custom.audit.logger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.sample.custom.tomcat.valve.RequestDataExtractorValve.Constants;
 import org.slf4j.MDC;
 import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
 import org.wso2.carbon.user.core.UserStoreManager;
-import org.sample.custom.tomcat.valve.RequestDataExtractorValve.Constants;
 
 import java.time.Instant;
 
@@ -13,55 +13,68 @@ public class CustomAuditLogger extends AbstractIdentityUserOperationEventListene
     private static final Log log = LogFactory.getLog(CustomAuditLogger.class);
     private static final int DEFAULT_EXECUTION_ORDER = 99;
 
+    public static void logFromMDCData() {
+        final String logMessage = MDC.get(Constants.LOG_MESSAGE);
+
+        if (logMessage != null) {
+            final String userName = MDC.get(Constants.USER_NAME);
+            final String instant = MDC.get(Constants.INSTANT);
+            final String userAgent = MDC.get(Constants.USER_AGENT);
+            final String referer = MDC.get(Constants.REFERER);
+            final String xForwardedFor = MDC.get(Constants.X_FORWARDED_FOR);
+            final String statusCode = MDC.get(Constants.HTTP_STATUS_CODE);
+
+            log.info(String.format(logMessage, userName, instant, userAgent, referer, xForwardedFor, statusCode));
+        } else {
+            log.debug("Cannot log with a null message.");
+        }
+    }
+
     @Override
     public int getExecutionOrderId() {
-        int result = super.getOrderId();  // use the value from the event listener configuration, if any
+        final int result = super.getOrderId();  // use the value from the event listener configuration, if any
         return result <= 0 ? DEFAULT_EXECUTION_ORDER : result;  // otherwise use the default value
     }
 
     @Override
-    public boolean doPreAuthenticate(String userName, Object credential, UserStoreManager userStoreManager) {
+    public boolean doPreAuthenticate(final String userName, final Object credential, final UserStoreManager userStoreManager) {
         if (isEnable()) {  // if event listener is enabled in the IS deployment configuration
-            log.info(String.format(LogMessage.PRE_AUTHENTICATE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF,
-                    userName,
-                    Instant.now().toString(),  // UTC timestamp string
-                    MDC.get(Constants.USER_AGENT),
-                    MDC.get(Constants.REFERER),
-                    MDC.get(Constants.X_FORWARDED_FOR)
-            ));
+            MDC.put(Constants.LOG_MESSAGE, LogMessage.PRE_AUTHENTICATE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC);
+            MDC.put(Constants.AUTHENTICATED, String.valueOf(false));
+            MDC.put(Constants.USER_NAME, userName);
+            MDC.put(Constants.INSTANT, Instant.now().toString());  // UTC timestamp string
         }
 
         return true;
     }
 
     @Override
-    public boolean doPostAuthenticate(String userName, boolean authenticated, UserStoreManager userStoreManager) {
+    public boolean doPostAuthenticate(final String userName, final boolean authenticated, final UserStoreManager userStoreManager) {
         if (isEnable()) {  // if event listener is enabled in the IS deployment configuration
-            log.info(String.format(authenticated ?
-                            LogMessage.POST_AUTHENTICATE_SUCCESS_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF :
-                            LogMessage.POST_AUTHENTICATE_FAILURE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF,
-                    userName,
-                    Instant.now().toString(),  // UTC timestamp string
-                    MDC.get(Constants.USER_AGENT),
-                    MDC.get(Constants.REFERER),
-                    MDC.get(Constants.X_FORWARDED_FOR)
-            ));
+            final String message = authenticated ?
+                    LogMessage.POST_AUTHENTICATE_SUCCESS_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC :
+                    LogMessage.POST_AUTHENTICATE_FAILURE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC;
+
+            MDC.put(Constants.AUTHENTICATED, String.valueOf(authenticated));
+            MDC.put(Constants.LOG_MESSAGE, message);
+            MDC.put(Constants.USER_NAME, userName);
+            MDC.put(Constants.INSTANT, Instant.now().toString());  // UTC timestamp string
         }
 
         return true;
     }
 
     private static final class LogMessage {
-        private static final String PRE_AUTHENTICATE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF =
+        private static final String PRE_AUTHENTICATE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC =
                 "Login attempt for username '%s' at %s. " +
-                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s";
+                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s | Status-Code: %s";
 
-        private static final String POST_AUTHENTICATE_SUCCESS_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF =
+        private static final String POST_AUTHENTICATE_SUCCESS_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC =
                 "Login successful for username '%s' at %s. " +
-                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s";
+                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s | Status-Code: %s";
 
-        private static final String POST_AUTHENTICATE_FAILURE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF =
+        private static final String POST_AUTHENTICATE_FAILURE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC =
                 "Login failed for username '%s' at %s. " +
-                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s";
+                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s | Status-Code: %s";
     }
 }

--- a/src/main/java/org/sample/custom/audit/logger/CustomAuditLogger.java
+++ b/src/main/java/org/sample/custom/audit/logger/CustomAuditLogger.java
@@ -2,7 +2,7 @@ package org.sample.custom.audit.logger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.sample.custom.tomcat.valve.RequestDataExtractorValve.Constants;
+import org.sample.custom.tomcat.valve.CustomAuditLoggerValve.Constants;
 import org.slf4j.MDC;
 import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
 import org.wso2.carbon.user.core.UserStoreManager;

--- a/src/main/java/org/sample/custom/tomcat/valve/RequestDataExtractorValve.java
+++ b/src/main/java/org/sample/custom/tomcat/valve/RequestDataExtractorValve.java
@@ -3,6 +3,9 @@ package org.sample.custom.tomcat.valve;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sample.custom.audit.logger.CustomAuditLogger;
 import org.slf4j.MDC;
 
 import javax.servlet.ServletException;
@@ -11,6 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class RequestDataExtractorValve extends ValveBase {
+    private static final Log log = LogFactory.getLog(RequestDataExtractorValve.class);
 
     @Override
     public void invoke(final Request request, final Response response) throws ServletException, IOException {
@@ -29,7 +33,20 @@ public class RequestDataExtractorValve extends ValveBase {
                 MDC.put(Constants.REFERER, referer);
             }
 
+            // Call the next valve in the pipeline. The response will be populated
+            // after this call returns.
             getNext().invoke(request, response);
+
+            // Now the response object should have the status code
+            // This line is reached after the Identity Server executed (including CustomAuditLogger)
+            // has likely completed for this specific HTTP request processing path.
+            MDC.put(Constants.HTTP_STATUS_CODE, Integer.toString(response.getStatus()));
+
+            // Trigger the logging
+            CustomAuditLogger.logFromMDCData();
+        } catch (Throwable e) {
+            // Prevent any errors from propagating and failing healthy requests to the client
+            log.debug("Error while logging request data", e);
         } finally {
             // Unset the MDC thread locals after use (request should be completed) to avoid memory leaks
             unsetMDCThreadLocals();
@@ -44,11 +61,21 @@ public class RequestDataExtractorValve extends ValveBase {
         public static final String USER_AGENT = "User-Agent";
         public static final String X_FORWARDED_FOR = "X-Forwarded-For";
         public static final String REFERER = "Referer";
+        public static final String INSTANT = "Instant";
+        public static final String USER_NAME = "UserName";
+        public static final String AUTHENTICATED = "Authenticated";
+        public static final String LOG_MESSAGE = "LogMessage";
+        public static final String HTTP_STATUS_CODE = "HttpStatusCode";
 
         public static final List<String> REMOVAL_LIST = Arrays.asList(
                 USER_AGENT,
                 X_FORWARDED_FOR,
-                REFERER
+                REFERER,
+                INSTANT,
+                USER_NAME,
+                AUTHENTICATED,
+                LOG_MESSAGE,
+                HTTP_STATUS_CODE
         );
     }
 }


### PR DESCRIPTION
This PR fixes an issue where we couldn't easily include HTTP response attributes (e.g., the status code) in the audit messages from our `CustomAuditLogger`. This was mainly because the listener runs before the final response details, like the status, are actually set.

To address this, the `RequestDataExtractorValve` has been renamed to `CustomAuditLoggerValve`, as its role has expanded from just extracting request data to also orchestrating and triggering the audit log message. The `CustomAuditLoggerValve` still puts request headers into MDC early in the process. Meanwhile, the `CustomAuditLogger` (our event listener) has been updated so its methods now add their specific event context (like username, event time, and the appropriate log message template) directly to MDC, instead of logging themselves.

After the Identity Server finishes its work for the request (when `getNext()` returns), the `CustomAuditLoggerValve` grabs the HTTP response status code (and potentially other response attributes in the future) and adds it to MDC. 
Then, in its `finally` block, it calls the new static `CustomAuditLogger.logFromMDCData()` method, which pulls everything together from MDC – request headers, listener event details, and the response status code – to write one complete audit log entry, right before the valve cleans up MDC. 

The main benefit is that we can now reliably get HTTP response-specific information into these logs, giving us a much fuller and more useful picture for auditing.
