### PR TITLE
Change `CustomAuditLogger` from an user operation listener to a event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Custom Audit Logger
 
-This project includes a custom user operation event listener `CustomAuditLogger` that intercepts 
-pre- and post-authentication for auditing purposes, and a Tomcat Valve `RequestDataExtractorValve` for 
-retrieving HTTP request information (e.g., HTTP headers) and adding it to SLF4J's Mapped Diagnostic Context (MDC) map 
+This project includes a custom event handler `CustomAuditLogger` that intercepts authentication success and failure 
+for auditing purposes, and a Tomcat Valve `CustomAuditLoggerValve` for retrieving HTTP request and response information 
+(e.g., HTTP headers, status code) and adding it to SLF4J's Mapped Diagnostic Context (MDC) map 
 so that it can be used in `CustomAuditLogger` where such information is not available. 
 
-See [1] for more information on User Operation Listeners, and [2][3] for more information on Tomcat Valves.
+See [1] for more information on Event Handlers, and [2][3] for more information on Tomcat Valves.
 
 This base version logs the following HTTP headers:
 
@@ -19,12 +19,9 @@ This base version logs the following HTTP headers:
 
 Add the below to the `<IS_HOME>/repository/conf/deployment.toml` file:
 ```toml
-[[event_listener]]
-id = "custom_audit_logger"
-type = "org.wso2.carbon.user.core.listener.UserOperationEventListener"
-name = "org.sample.custom.audit.logger.CustomAuditLogger"
-order = "9983"
-enable = true
+[[event_handler]]
+name = "CustomAuditLogger"
+subscriptions = ["AUTHENTICATION_SUCCESS", "AUTHENTICATION_FAILURE"]
 
 [[catalina.valves]]
 properties.className = "org.sample.custom.tomcat.valve.CustomAuditLoggerValve"
@@ -55,7 +52,7 @@ appender.CUSTOM_AUDIT_LOGFILE.filter.threshold.level = INFO
 ```
 
 * _The policies for this appender rotate the log file every 10 MB and every day. You can adjust this to your liking, see [5]._
-* _You can adjust the appender log pattern (`appender.CUSTOM_AUDIT_LOGFILE.layout.pattern`)  with the pattern converters that adjust best to your requirement, see [6]. It's recommended to keep the `%X{Correlation-ID}` for cross-reference with other log files._
+* _You can adjust the appender log pattern (`appender.CUSTOM_AUDIT_LOGFILE.layout.pattern`) with the pattern converters that adjust best to your requirement, see [6]. It's recommended to keep the `%X{Correlation-ID}` for cross-reference with other log files._
 
 2. Create a Log4J2 Logger [7] named `CUSTOM_AUDIT_LOG` mapped to the `org.sample.custom.audit.logger.CustomAuditLogger` class, set the appender reference to `CUSTOM_AUDIT_LOGFILE`, and add it to the existing `loggers` variable:
 
@@ -70,7 +67,7 @@ logger.CUSTOM_AUDIT_LOG.additivity = false
 
 ---
 
-- [1] https://is.docs.wso2.com/en/5.10.0/develop/user-store-listeners/
+- [1] https://is.docs.wso2.com/en/5.10.0/develop/writing-a-custom-event-handler/
 - [2] https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html
 - [3] https://tomcat.apache.org/tomcat-9.0-doc/api/org/apache/catalina/Valve.html
 - [4] https://logging.apache.org/log4j/2.x/manual/appenders.html

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.event</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <version>${apache.felix.scr.ds.annotations.version}</version>
@@ -128,6 +138,8 @@
                             org.apache.catalina.*; version="1.7.0",
 
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.framework.version.range}",
+                            org.wso2.carbon.identity.event.*; version="${carbon.identity.framework.version.range}",
+                            org.wso2.carbon.identity.application.*; version="${carbon.identity.framework.version.range}",
 
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.version.range}",
                             org.wso2.carbon.user.api.*; version="${carbon.user.api.version.range}",
@@ -157,6 +169,7 @@
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
 
         <carbon.kernel.version.range>[4.6.0, 5.0.0)</carbon.kernel.version.range>
+        <carbon.user.api.version.range>[1.0.1, 2.0.0)</carbon.user.api.version.range>
 
         <!--Carbon Identity Framework-->
         <carbon.identity.framework.version>5.17.5</carbon.identity.framework.version>

--- a/src/main/java/org/sample/custom/audit/logger/CustomAuditLogger.java
+++ b/src/main/java/org/sample/custom/audit/logger/CustomAuditLogger.java
@@ -2,16 +2,35 @@ package org.sample.custom.audit.logger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.sample.custom.audit.logger.internal.ServiceHolder;
+import org.sample.custom.audit.logger.utils.Utils;
 import org.sample.custom.tomcat.valve.CustomAuditLoggerValve.Constants;
 import org.slf4j.MDC;
-import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
+import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorStatus;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.user.core.UserStoreManager;
 
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
-public class CustomAuditLogger extends AbstractIdentityUserOperationEventListener {
+public class CustomAuditLogger extends AbstractEventHandler {
     private static final Log log = LogFactory.getLog(CustomAuditLogger.class);
-    private static final int DEFAULT_EXECUTION_ORDER = 99;
+    private static final String HANDLER_NAME = "CustomAuditLogger";
+    private static final int PRIORITY = 50;
+
+    private static final Set<String> SUBSCRIPTIONS = new HashSet<>(Arrays.asList(
+            IdentityEventConstants.EventName.AUTHENTICATION_SUCCESS.name(),
+            IdentityEventConstants.EventName.AUTHENTICATION_FAILURE.name()
+    ));
 
     public static void logFromMDCData() {
         final String logMessage = MDC.get(Constants.LOG_MESSAGE);
@@ -23,58 +42,80 @@ public class CustomAuditLogger extends AbstractIdentityUserOperationEventListene
             final String referer = MDC.get(Constants.REFERER);
             final String xForwardedFor = MDC.get(Constants.X_FORWARDED_FOR);
             final String statusCode = MDC.get(Constants.HTTP_STATUS_CODE);
+            final String roleList = MDC.get(Constants.ROLE_LIST);
 
-            log.info(String.format(logMessage, userName, instant, userAgent, referer, xForwardedFor, statusCode));
+            log.info(String.format(logMessage, userName, instant, userAgent, referer, xForwardedFor, statusCode, roleList));
         } else {
             log.debug("Cannot log with a null message.");
         }
     }
 
     @Override
-    public int getExecutionOrderId() {
-        final int result = super.getOrderId();  // use the value from the event listener configuration, if any
-        return result <= 0 ? DEFAULT_EXECUTION_ORDER : result;  // otherwise use the default value
-    }
+    public void handleEvent(final Event event) throws IdentityEventException {
+        final String eventName = event.getEventName();
 
-    @Override
-    public boolean doPreAuthenticate(final String userName, final Object credential, final UserStoreManager userStoreManager) {
-        if (isEnable()) {  // if event listener is enabled in the IS deployment configuration
-            MDC.put(Constants.LOG_MESSAGE, LogMessage.PRE_AUTHENTICATE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC);
-            MDC.put(Constants.AUTHENTICATED, String.valueOf(false));
-            MDC.put(Constants.USER_NAME, userName);
-            MDC.put(Constants.INSTANT, Instant.now().toString());  // UTC timestamp string
-        }
+        log.debug(eventName + " event received to " + getName() + ".");
 
-        return true;
-    }
+        if (!SUBSCRIPTIONS.contains(eventName)) return;
 
-    @Override
-    public boolean doPostAuthenticate(final String userName, final boolean authenticated, final UserStoreManager userStoreManager) {
-        if (isEnable()) {  // if event listener is enabled in the IS deployment configuration
+        try {
+            final Map<String, Object> eventProperties = event.getEventProperties();
+            final AuthenticationContext context = Utils.getAuthenticationContextFromProperties(eventProperties);
+            final Map<String, Object> params = Utils.getParamsFromProperties(eventProperties);
+            final AuthenticatorStatus status = Utils.getAuthenticatorStatusFromProperties(eventProperties);
+
+            final boolean authenticated = status == AuthenticatorStatus.PASS;
+            final AuthenticatedUser user = context.getLastAuthenticatedUser();
+
+            final UserStoreManager userStoreManager;
+
+            if (user.getUserStoreDomain() != null) {
+                userStoreManager = ServiceHolder.getInstance()
+                        .getRealmService()
+                        .getBootstrapRealm()
+                        .getUserStoreManager()
+                        .getSecondaryUserStoreManager(user.getUserStoreDomain());
+            } else {
+                userStoreManager = ServiceHolder.getInstance()
+                        .getRealmService()
+                        .getBootstrapRealm()
+                        .getUserStoreManager();
+            }
+
+            final String[] roleArray = userStoreManager.getRoleListOfUser(user.getUserName());
+
             final String message = authenticated ?
-                    LogMessage.POST_AUTHENTICATE_SUCCESS_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC :
-                    LogMessage.POST_AUTHENTICATE_FAILURE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC;
+                    LogMessage.POST_AUTHENTICATE_SUCCESS_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC_RL :
+                    LogMessage.POST_AUTHENTICATE_FAILURE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC_RL;
 
             MDC.put(Constants.AUTHENTICATED, String.valueOf(authenticated));
             MDC.put(Constants.LOG_MESSAGE, message);
-            MDC.put(Constants.USER_NAME, userName);
+            MDC.put(Constants.USER_NAME, user.getUserName());
             MDC.put(Constants.INSTANT, Instant.now().toString());  // UTC timestamp string
-        }
+            MDC.put(Constants.ROLE_LIST, Arrays.toString(roleArray));
 
-        return true;
+        } catch (final Throwable e) {
+            log.error("Error while handling event: " + eventName, e);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return HANDLER_NAME;
+    }
+
+    @Override
+    public int getPriority(final MessageContext messageContext) {
+        return PRIORITY;
     }
 
     private static final class LogMessage {
-        private static final String PRE_AUTHENTICATE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC =
-                "Login attempt for username '%s' at %s. " +
-                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s | Status-Code: %s";
-
-        private static final String POST_AUTHENTICATE_SUCCESS_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC =
+        private static final String POST_AUTHENTICATE_SUCCESS_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC_RL =
                 "Login successful for username '%s' at %s. " +
-                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s | Status-Code: %s";
+                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s | Status-Code: %s | Role-List: %s";
 
-        private static final String POST_AUTHENTICATE_FAILURE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC =
+        private static final String POST_AUTHENTICATE_FAILURE_MESSAGE_UNAME_ATTIME_UAGENT_REF_XFF_SC_RL =
                 "Login failed for username '%s' at %s. " +
-                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s | Status-Code: %s";
+                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s | Status-Code: %s | Role-List: %s";
     }
 }

--- a/src/main/java/org/sample/custom/audit/logger/internal/ServiceHolder.java
+++ b/src/main/java/org/sample/custom/audit/logger/internal/ServiceHolder.java
@@ -1,0 +1,27 @@
+package org.sample.custom.audit.logger.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.user.core.service.RealmService;
+
+public class ServiceHolder {
+    private static final ServiceHolder instance = new ServiceHolder();
+    private static final Log log = LogFactory.getLog(ServiceHolder.class);
+
+    private RealmService realmService;
+
+    private ServiceHolder() {
+    }
+
+    public static ServiceHolder getInstance() {
+        return instance;
+    }
+
+    public RealmService getRealmService() {
+        return realmService;
+    }
+
+    public void setRealmService(RealmService realmService) {
+        this.realmService = realmService;
+    }
+}

--- a/src/main/java/org/sample/custom/audit/logger/utils/Utils.java
+++ b/src/main/java/org/sample/custom/audit/logger/utils/Utils.java
@@ -1,0 +1,96 @@
+package org.sample.custom.audit.logger.utils;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorStatus;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserCoreConstants;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class Utils {
+    private static final Log log = LogFactory.getLog(Utils.class);
+
+    private Utils() {
+        // Prevent instantiation
+    }
+
+    public static String getUserStoreDomain(org.wso2.carbon.user.api.UserStoreManager userStoreManager) {
+        String domainNameProperty = null;
+        if (userStoreManager instanceof org.wso2.carbon.user.core.UserStoreManager) {
+            domainNameProperty = ((org.wso2.carbon.user.core.UserStoreManager)
+                    userStoreManager).getRealmConfiguration()
+                    .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+            if (StringUtils.isBlank(domainNameProperty)) {
+                domainNameProperty = IdentityUtil.getPrimaryDomainName();
+            }
+        }
+        return domainNameProperty;
+    }
+
+    public static String getTenantDomain(org.wso2.carbon.user.api.UserStoreManager userStoreManager) throws IdentityEventException {
+        try {
+            return IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
+        } catch (UserStoreException e) {
+            throw new IdentityEventException(e.getMessage(), e);
+        }
+    }
+
+    public static AuthenticationContext getAuthenticationContextFromProperties(final Map<String, Object> properties) {
+        return (AuthenticationContext) properties.get(IdentityEventConstants.EventProperty.CONTEXT);
+    }
+
+    public static Map<String, Object> getParamsFromProperties(final Map<String, Object> properties) {
+        final Map<String, Object> params = safeCastToMapStringObject(properties.get(IdentityEventConstants.EventProperty.PARAMS));
+        return params != null ? params : new HashMap<>();
+    }
+
+    public static AuthenticatorStatus getAuthenticatorStatusFromProperties(final Map<String, Object> properties) {
+        return (AuthenticatorStatus) properties.get(IdentityEventConstants.EventProperty.AUTHENTICATION_STATUS);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> safeCastToMapStringObject(final Object obj) {
+        if (!(obj instanceof Map)) {
+            return null;
+        }
+
+        final Map<?, ?> map = (Map<?, ?>) obj;
+
+        for (final Object key : map.keySet()) {
+            if (!(key instanceof String)) {
+                return null;
+            }
+        }
+
+        return (Map<String, Object>) map;
+    }
+
+    public static Map<String, Object> safeConvertToMapStringObject(final Object obj) {
+        if (!(obj instanceof Map)) {
+            return null;
+        }
+
+        final Map<?, ?> sourceMap = (Map<?, ?>) obj;
+        final Map<String, Object> resultMap = new HashMap<>();
+
+        for (final Map.Entry<?, ?> entry : sourceMap.entrySet()) {
+            final Object key = entry.getKey();
+
+            if (!(key instanceof String)) {
+                return null;
+            }
+
+            resultMap.put((String) key, entry.getValue());
+        }
+
+        return resultMap;
+    }
+}

--- a/src/main/java/org/sample/custom/tomcat/valve/CustomAuditLoggerValve.java
+++ b/src/main/java/org/sample/custom/tomcat/valve/CustomAuditLoggerValve.java
@@ -70,6 +70,7 @@ public class CustomAuditLoggerValve extends ValveBase {
         public static final String AUTHENTICATED = "Authenticated";
         public static final String LOG_MESSAGE = "LogMessage";
         public static final String HTTP_STATUS_CODE = "HttpStatusCode";
+        public static final String ROLE_LIST = "RoleList";
 
         public static final List<String> REMOVAL_LIST = Arrays.asList(
                 USER_AGENT,
@@ -77,6 +78,7 @@ public class CustomAuditLoggerValve extends ValveBase {
                 REFERER,
                 INSTANT,
                 USER_NAME,
+                ROLE_LIST,
                 AUTHENTICATED,
                 LOG_MESSAGE,
                 HTTP_STATUS_CODE


### PR DESCRIPTION
Currently, the `CustomAuditLogger` class is implemented as an user operation listener and depends on `doPreAuthenticate` and `doPostAuthenticate` methods, which is only triggered by local authenticators, and causes missing log entries for federated scenarios.

This PR changes the implementation to an event handler, which ideally subscribes to the `AUTHENTICATION_SUCESS` and `AUTHENTICATION_FAILURE` events. 

All functional logic remains the same.

Configuration must go from:

```toml
[[event_listener]]
id = "custom_audit_logger"
type = "org.wso2.carbon.user.core.listener.UserOperationEventListener"
name = "org.sample.custom.audit.logger.CustomAuditLogger"
order = "9983"
enable = true

[[catalina.valves]]
properties.className = "org.sample.custom.tomcat.valve.CustomAuditLoggerValve"
```

to:

```toml
[[event_handler]]
name = "CustomAuditLogger"
subscriptions = ["AUTHENTICATION_SUCCESS", "AUTHENTICATION_FAILURE"]

[[catalina.valves]]
properties.className = "org.sample.custom.tomcat.valve.CustomAuditLoggerValve"
```