### PR TITLE
Intercept OAuth authentication flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Custom Audit Logger
 
-This project includes a custom event handler `CustomAuditLogger` that intercepts authentication success and failure 
-for auditing purposes, and a Tomcat Valve `CustomAuditLoggerValve` for retrieving HTTP request and response information 
-(e.g., HTTP headers, status code) and adding it to SLF4J's Mapped Diagnostic Context (MDC) map 
-so that it can be used in `CustomAuditLogger` where such information is not available. 
+This project includes a custom event handler `CustomAuditLogger` that intercepts authentication success and failure
+events for auditing purposes, an OAuth event interceptor to catch authentication flows that don't trigger
+authentication events (e.g., password grant, JWT-bearer grant), and a Tomcat Valve `CustomAuditLoggerValve`
+for retrieving HTTP request and response information (e.g., HTTP headers, status code) and adding it to SLF4J's
+Mapped Diagnostic Context (MDC) map so that it can be used in `CustomAuditLogger` where such information is not available.
 
 See [1] for more information on Event Handlers, and [2][3] for more information on Tomcat Valves.
 
@@ -21,7 +22,7 @@ Add the below to the `<IS_HOME>/repository/conf/deployment.toml` file:
 ```toml
 [[event_handler]]
 name = "CustomAuditLogger"
-subscriptions = ["AUTHENTICATION_SUCCESS", "AUTHENTICATION_FAILURE"]
+subscriptions = ["AUTHENTICATION_SUCCESS", "AUTHENTICATION_FAILURE", "AUTHENTICATION_STEP_FAILURE"]
 
 [[catalina.valves]]
 properties.className = "org.sample.custom.tomcat.valve.CustomAuditLoggerValve"

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,16 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <version>${apache.felix.scr.ds.annotations.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+            <artifactId>org.wso2.carbon.identity.oauth</artifactId>
+            <version>${carbon.identity.oauth.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.extension.identity.oauth2.grantType.jwt</groupId>
+            <artifactId>org.wso2.carbon.identity.oauth2.grant.jwt</artifactId>
+            <version>${carbon.identity.oauth.grant.jwt.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -123,8 +133,7 @@
                         </Private-Package>
                         <Export-Package>
                             !org.sample.custom.audit.logger.internal,
-                            org.sample.custom.audit.logger.*; version="${project.version}",
-                            org.sample.custom.tomcat.valve.*; version="${project.version}"
+                            org.sample.custom.*; version="${project.version}"
                         </Export-Package>
                         <Import-Package>
                             javax.servlet.*; version="${javax.servlet.version.range}",
@@ -140,6 +149,10 @@
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.framework.version.range}",
                             org.wso2.carbon.identity.event.*; version="${carbon.identity.framework.version.range}",
                             org.wso2.carbon.identity.application.*; version="${carbon.identity.framework.version.range}",
+
+                            org.wso2.carbon.identity.oauth.*; version="${carbon.identity.oauth.version.range}",
+                            org.wso2.carbon.identity.oauth2.*; version="${carbon.identity.oauth.version.range}",
+                            org.wso2.carbon.identity.oauth2.grant.jwt.*; version="${carbon.identity.oauth.grant.jwt.version.range}",
 
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.version.range}",
                             org.wso2.carbon.user.api.*; version="${carbon.user.api.version.range}",
@@ -173,8 +186,12 @@
 
         <!--Carbon Identity Framework-->
         <carbon.identity.framework.version>5.17.5</carbon.identity.framework.version>
+        <carbon.identity.oauth.version>6.4.2</carbon.identity.oauth.version>
+        <carbon.identity.oauth.grant.jwt.version>1.0.26</carbon.identity.oauth.grant.jwt.version>
 
-        <carbon.identity.framework.version.range>[5.17.5,6.0.0)</carbon.identity.framework.version.range>
+        <carbon.identity.framework.version.range>[5.17.5, 6.0.0)</carbon.identity.framework.version.range>
+        <carbon.identity.oauth.version.range>[6.4.2, 7.0.0)</carbon.identity.oauth.version.range>
+        <carbon.identity.oauth.grant.jwt.version.range>[1.0.26, 2.0.0)</carbon.identity.oauth.grant.jwt.version.range>
 
         <!-- Common versions -->
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
@@ -183,10 +200,10 @@
         <osgi.framework.version.range>[1.7.0, 2.0.0)</osgi.framework.version.range>
         <osgi.service.component.version.range>[1.2.0, 2.0.0)</osgi.service.component.version.range>
 
-        <org.slf4j.version.range>[1.6.1,2.0.0)</org.slf4j.version.range>
+        <org.slf4j.version.range>[1.6.1, 2.0.0)</org.slf4j.version.range>
         <javax.servlet.version.range>[2.6.0, 3.0.0)</javax.servlet.version.range>
 
-        <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
-        <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
+        <commons-lang.wso2.osgi.version.range>[2.6.0, 3.0.0)</commons-lang.wso2.osgi.version.range>
+        <commons-logging.osgi.version.range>[1.2, 2.0)</commons-logging.osgi.version.range>
     </properties>
 </project>

--- a/src/main/java/org/sample/custom/CustomOAuthTokenInterceptor.java
+++ b/src/main/java/org/sample/custom/CustomOAuthTokenInterceptor.java
@@ -1,0 +1,106 @@
+package org.sample.custom;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sample.custom.audit.logger.internal.ServiceHolder;
+import org.sample.custom.common.Constants;
+import org.slf4j.MDC;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.event.AbstractOAuthEventInterceptor;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
+import org.wso2.carbon.identity.oauth2.grant.jwt.JWTConstants;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.user.core.UserStoreManager;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Map;
+
+public class CustomOAuthTokenInterceptor extends AbstractOAuthEventInterceptor {
+    private static final Log log = LogFactory.getLog(CustomOAuthTokenInterceptor.class);
+
+    private static boolean isPasswordGrant(final OAuth2AccessTokenReqDTO tokenReqDTO) {
+        return OAuthConstants.GrantTypes.PASSWORD.equals(tokenReqDTO.getGrantType());
+    }
+
+    private static boolean isJWTBearerGrant(final OAuth2AccessTokenReqDTO tokenReqDTO) {
+        return JWTConstants.OAUTH_JWT_BEARER_GRANT_TYPE.equals(tokenReqDTO.getGrantType());
+    }
+
+    @Override
+    public boolean isEnabled() {
+        // enabled by default
+        return true;
+    }
+
+    @Override
+    public void onPreTokenIssue(final OAuth2AccessTokenReqDTO tokenReqDTO,
+                                final OAuthTokenReqMessageContext tokReqMsgCtx,
+                                final Map<String, Object> params) {
+        // Log grant type
+        MDC.put(Constants.MDC.GRANT_TYPE, tokenReqDTO.getGrantType());
+    }
+
+    @Override
+    public void onPostTokenIssue(final OAuth2AccessTokenReqDTO tokenReqDTO,
+                                 final OAuth2AccessTokenRespDTO tokenRespDTO,
+                                 final OAuthTokenReqMessageContext tokReqMsgCtx,
+                                 final Map<String, Object> params) {
+        if (!isPasswordGrant(tokenReqDTO) && !isJWTBearerGrant(tokenReqDTO)) return;
+
+        try {
+            final boolean authenticated = isTokenRequestSuccessful(tokReqMsgCtx) && !tokenRespDTO.isError();
+
+            MDC.put(Constants.MDC.AUTHENTICATED, String.valueOf(authenticated));
+            MDC.put(Constants.MDC.INSTANT, Instant.now().toString());  // UTC timestamp string
+
+            if (authenticated) {
+                final AuthenticatedUser user = getAuthenticatedUser(tokReqMsgCtx);
+
+                final UserStoreManager userStoreManager;
+
+                if (user.getUserStoreDomain() != null) {
+                    userStoreManager = ServiceHolder.getInstance()
+                            .getRealmService()
+                            .getBootstrapRealm()
+                            .getUserStoreManager()
+                            .getSecondaryUserStoreManager(user.getUserStoreDomain());
+                } else {
+                    userStoreManager = ServiceHolder.getInstance()
+                            .getRealmService()
+                            .getBootstrapRealm()
+                            .getUserStoreManager();
+                }
+
+                final String[] roleArray = userStoreManager.getRoleListOfUser(user.getUserName());
+
+                MDC.put(Constants.MDC.USER_NAME, user.getUserName());
+                MDC.put(Constants.MDC.ROLE_LIST, Arrays.toString(roleArray));
+
+                MDC.put(Constants.MDC.LOG_MESSAGE, Constants.LogMessage.AUTHENTICATION_SUCCESS_MESSAGE_UNAME_GTYPE_ATTIME_UAGENT_REF_XFF_SC_RL);
+            } else {
+                final AuthenticatedUser user = getAuthenticatedUser(tokReqMsgCtx);
+                final String username = user != null ? user.getUserName() : getResourceOwnerUsername(tokReqMsgCtx);
+
+                MDC.put(Constants.MDC.USER_NAME, username);
+                MDC.put(Constants.MDC.LOG_MESSAGE, Constants.LogMessage.AUTHENTICATION_FAILURE_MESSAGE_UNAME_GTYPE_ATTIME_UAGENT_REF_XFF_SC);
+            }
+        } catch (Throwable e) {
+            log.error(String.format("Error while intercepting token request for %s grant type: ", tokenReqDTO.getGrantType()), e);
+        }
+    }
+
+    private String getResourceOwnerUsername(final OAuthTokenReqMessageContext tokReqMsgCtx) {
+        return tokReqMsgCtx.getOauth2AccessTokenReqDTO().getResourceOwnerUsername();
+    }
+
+    private AuthenticatedUser getAuthenticatedUser(final OAuthTokenReqMessageContext tokReqMsgCtx) {
+        return tokReqMsgCtx.getAuthorizedUser();
+    }
+
+    private boolean isTokenRequestSuccessful(final OAuthTokenReqMessageContext tokReqMsgCtx) {
+        return tokReqMsgCtx.getAuthorizedUser() != null;
+    }
+}

--- a/src/main/java/org/sample/custom/common/Constants.java
+++ b/src/main/java/org/sample/custom/common/Constants.java
@@ -1,0 +1,42 @@
+package org.sample.custom.common;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class Constants {
+    public static final class MDC {
+        public static final String USER_AGENT = "User-Agent";
+        public static final String X_FORWARDED_FOR = "X-Forwarded-For";
+        public static final String REFERER = "Referer";
+        public static final String INSTANT = "Instant";
+        public static final String USER_NAME = "UserName";
+        public static final String AUTHENTICATED = "Authenticated";
+        public static final String LOG_MESSAGE = "LogMessage";
+        public static final String HTTP_STATUS_CODE = "HttpStatusCode";
+        public static final String ROLE_LIST = "RoleList";
+        public static final String GRANT_TYPE = "GrantType";
+
+        public static final List<String> REMOVAL_LIST = Arrays.asList(
+                USER_AGENT,
+                X_FORWARDED_FOR,
+                REFERER,
+                INSTANT,
+                USER_NAME,
+                AUTHENTICATED,
+                LOG_MESSAGE,
+                HTTP_STATUS_CODE,
+                ROLE_LIST,
+                GRANT_TYPE
+        );
+    }
+
+    public static final class LogMessage {
+        public static final String AUTHENTICATION_SUCCESS_MESSAGE_UNAME_GTYPE_ATTIME_UAGENT_REF_XFF_SC_RL =
+                "Login successful for username '%s' with grant type '%s' at %s. " +
+                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s | Status-Code: %s | Role-List: %s";
+
+        public static final String AUTHENTICATION_FAILURE_MESSAGE_UNAME_GTYPE_ATTIME_UAGENT_REF_XFF_SC =
+                "Login failed for username '%s' with grant type '%s' at %s. " +
+                        "User Agent: %s | Referer: %s | X-Forwarded-For: %s | Status-Code: %s";
+    }
+}

--- a/src/main/java/org/sample/custom/tomcat/valve/CustomAuditLoggerValve.java
+++ b/src/main/java/org/sample/custom/tomcat/valve/CustomAuditLoggerValve.java
@@ -6,12 +6,11 @@ import org.apache.catalina.valves.ValveBase;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sample.custom.audit.logger.CustomAuditLogger;
+import org.sample.custom.common.Constants;
 import org.slf4j.MDC;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 public class CustomAuditLoggerValve extends ValveBase {
     private static final Log log = LogFactory.getLog(CustomAuditLoggerValve.class);
@@ -19,18 +18,18 @@ public class CustomAuditLoggerValve extends ValveBase {
     @Override
     public void invoke(final Request request, final Response response) throws ServletException, IOException {
         try {
-            final String userAgent = request.getHeader(Constants.USER_AGENT);
-            final String forwardedFor = request.getHeader(Constants.X_FORWARDED_FOR);
-            final String referer = request.getHeader(Constants.REFERER);
+            final String userAgent = request.getHeader(Constants.MDC.USER_AGENT);
+            final String forwardedFor = request.getHeader(Constants.MDC.X_FORWARDED_FOR);
+            final String referer = request.getHeader(Constants.MDC.REFERER);
 
             if (userAgent != null) {
-                MDC.put(Constants.USER_AGENT, userAgent);
+                MDC.put(Constants.MDC.USER_AGENT, userAgent);
             }
             if (forwardedFor != null) {
-                MDC.put(Constants.X_FORWARDED_FOR, forwardedFor);
+                MDC.put(Constants.MDC.X_FORWARDED_FOR, forwardedFor);
             }
             if (referer != null) {
-                MDC.put(Constants.REFERER, referer);
+                MDC.put(Constants.MDC.REFERER, referer);
             }
 
             // Call the next valve in the pipeline. The response will be populated
@@ -40,7 +39,7 @@ public class CustomAuditLoggerValve extends ValveBase {
             // Now the response object should have the status code
             // This line is reached after the Identity Server executed (including CustomAuditLogger)
             // has likely completed for this specific HTTP request processing path.
-            MDC.put(Constants.HTTP_STATUS_CODE, Integer.toString(response.getStatus()));
+            MDC.put(Constants.MDC.HTTP_STATUS_CODE, Integer.toString(response.getStatus()));
         } catch (Throwable e) {
             // Prevent any errors from propagating and failing healthy requests to the client
             log.debug("Error while extracting HTTP request/response data", e);
@@ -58,30 +57,6 @@ public class CustomAuditLoggerValve extends ValveBase {
     }
 
     private void unsetMDCThreadLocals() {
-        Constants.REMOVAL_LIST.forEach(MDC::remove);
-    }
-
-    public static final class Constants {
-        public static final String USER_AGENT = "User-Agent";
-        public static final String X_FORWARDED_FOR = "X-Forwarded-For";
-        public static final String REFERER = "Referer";
-        public static final String INSTANT = "Instant";
-        public static final String USER_NAME = "UserName";
-        public static final String AUTHENTICATED = "Authenticated";
-        public static final String LOG_MESSAGE = "LogMessage";
-        public static final String HTTP_STATUS_CODE = "HttpStatusCode";
-        public static final String ROLE_LIST = "RoleList";
-
-        public static final List<String> REMOVAL_LIST = Arrays.asList(
-                USER_AGENT,
-                X_FORWARDED_FOR,
-                REFERER,
-                INSTANT,
-                USER_NAME,
-                ROLE_LIST,
-                AUTHENTICATED,
-                LOG_MESSAGE,
-                HTTP_STATUS_CODE
-        );
+        Constants.MDC.REMOVAL_LIST.forEach(MDC::remove);
     }
 }


### PR DESCRIPTION
This PR introduces adds a new `AbstractOAuthEventInterceptor` service called `CustomOAuthTokenInterceptor`, which intercepts token issuance requests with the intent of capturing OAuth authentication flows that don't trigger authentication events, such as the password and JWT-bearer grant types.

It also introduces a new `Constant` class to centralise common strings, and updates the README with the revised information.