### PR TITLE
Fix multi-tenancy user data retrieval

### DIFF
--- a/src/main/java/org/sample/custom/CustomOAuthTokenInterceptor.java
+++ b/src/main/java/org/sample/custom/CustomOAuthTokenInterceptor.java
@@ -3,6 +3,7 @@ package org.sample.custom;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sample.custom.audit.logger.internal.ServiceHolder;
+import org.sample.custom.audit.logger.utils.Utils;
 import org.sample.custom.common.Constants;
 import org.slf4j.MDC;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
@@ -56,32 +57,16 @@ public class CustomOAuthTokenInterceptor extends AbstractOAuthEventInterceptor {
             MDC.put(Constants.MDC.AUTHENTICATED, String.valueOf(authenticated));
             MDC.put(Constants.MDC.INSTANT, Instant.now().toString());  // UTC timestamp string
 
+            final AuthenticatedUser user = getAuthenticatedUser(tokReqMsgCtx);
+
             if (authenticated) {
-                final AuthenticatedUser user = getAuthenticatedUser(tokReqMsgCtx);
-
-                final UserStoreManager userStoreManager;
-
-                if (user.getUserStoreDomain() != null) {
-                    userStoreManager = ServiceHolder.getInstance()
-                            .getRealmService()
-                            .getBootstrapRealm()
-                            .getUserStoreManager()
-                            .getSecondaryUserStoreManager(user.getUserStoreDomain());
-                } else {
-                    userStoreManager = ServiceHolder.getInstance()
-                            .getRealmService()
-                            .getBootstrapRealm()
-                            .getUserStoreManager();
-                }
-
+                final UserStoreManager userStoreManager = Utils.getUserStoreManagerFromUser(user);
                 final String[] roleArray = userStoreManager.getRoleListOfUser(user.getUserName());
 
                 MDC.put(Constants.MDC.USER_NAME, user.getUserName());
                 MDC.put(Constants.MDC.ROLE_LIST, Arrays.toString(roleArray));
-
                 MDC.put(Constants.MDC.LOG_MESSAGE, Constants.LogMessage.AUTHENTICATION_SUCCESS_MESSAGE_UNAME_GTYPE_ATTIME_UAGENT_REF_XFF_SC_RL);
             } else {
-                final AuthenticatedUser user = getAuthenticatedUser(tokReqMsgCtx);
                 final String username = user != null ? user.getUserName() : getResourceOwnerUsername(tokReqMsgCtx);
 
                 MDC.put(Constants.MDC.USER_NAME, username);

--- a/src/main/java/org/sample/custom/CustomOAuthTokenInterceptor.java
+++ b/src/main/java/org/sample/custom/CustomOAuthTokenInterceptor.java
@@ -2,7 +2,6 @@ package org.sample.custom;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.sample.custom.audit.logger.internal.ServiceHolder;
 import org.sample.custom.audit.logger.utils.Utils;
 import org.sample.custom.common.Constants;
 import org.slf4j.MDC;

--- a/src/main/java/org/sample/custom/audit/logger/CustomAuditLogger.java
+++ b/src/main/java/org/sample/custom/audit/logger/CustomAuditLogger.java
@@ -118,7 +118,6 @@ public class CustomAuditLogger extends AbstractEventHandler {
         }
     }
 
-
     @Override
     public String getName() {
         return HANDLER_NAME;

--- a/src/main/java/org/sample/custom/audit/logger/CustomAuditLogger.java
+++ b/src/main/java/org/sample/custom/audit/logger/CustomAuditLogger.java
@@ -2,7 +2,6 @@ package org.sample.custom.audit.logger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.sample.custom.audit.logger.internal.ServiceHolder;
 import org.sample.custom.audit.logger.utils.Utils;
 import org.sample.custom.common.Constants;
 import org.slf4j.MDC;
@@ -15,9 +14,7 @@ import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
-import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
-import org.wso2.carbon.user.core.service.RealmService;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -120,7 +117,6 @@ public class CustomAuditLogger extends AbstractEventHandler {
             log.error("Error while handling event: " + eventName, e);
         }
     }
-
 
 
     @Override

--- a/src/main/java/org/sample/custom/audit/logger/CustomAuditLogger.java
+++ b/src/main/java/org/sample/custom/audit/logger/CustomAuditLogger.java
@@ -16,6 +16,7 @@ import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -101,20 +102,21 @@ public class CustomAuditLogger extends AbstractEventHandler {
 
             if (authenticated) {
                 final AuthenticatedUser user = context.getLastAuthenticatedUser();
+                final RealmService realmService = ServiceHolder.getInstance().getRealmService();
+                final String tenantDomain = user.getTenantDomain();
+                final int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
 
                 final UserStoreManager userStoreManager;
 
                 if (user.getUserStoreDomain() != null) {
-                    userStoreManager = ServiceHolder.getInstance()
-                            .getRealmService()
-                            .getBootstrapRealm()
-                            .getUserStoreManager()
+                    userStoreManager = ((UserStoreManager) realmService
+                            .getTenantUserRealm(tenantId)
+                            .getUserStoreManager())
                             .getSecondaryUserStoreManager(user.getUserStoreDomain());
                 } else {
-                    userStoreManager = ServiceHolder.getInstance()
-                            .getRealmService()
-                            .getBootstrapRealm()
-                            .getUserStoreManager();
+                    userStoreManager = ((UserStoreManager) realmService
+                            .getTenantUserRealm(tenantId)
+                            .getUserStoreManager());
                 }
 
                 final String[] roleArray = userStoreManager.getRoleListOfUser(user.getUserName());

--- a/src/main/java/org/sample/custom/audit/logger/utils/Utils.java
+++ b/src/main/java/org/sample/custom/audit/logger/utils/Utils.java
@@ -2,11 +2,16 @@ package org.sample.custom.audit.logger.utils;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.sample.custom.audit.logger.internal.ServiceHolder;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorStatus;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,6 +21,26 @@ public final class Utils {
 
     private Utils() {
         // Prevent instantiation
+    }
+
+    public static UserStoreManager getUserStoreManagerFromUser(final AuthenticatedUser user) throws UserStoreException {
+        final RealmService realmService = ServiceHolder.getInstance().getRealmService();
+        final String tenantDomain = user.getTenantDomain();
+        final int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
+
+        final UserStoreManager userStoreManager;
+
+        if (user.getUserStoreDomain() != null) {
+            userStoreManager = ((UserStoreManager) realmService
+                    .getTenantUserRealm(tenantId)
+                    .getUserStoreManager())
+                    .getSecondaryUserStoreManager(user.getUserStoreDomain());
+        } else {
+            userStoreManager = ((UserStoreManager) realmService
+                    .getTenantUserRealm(tenantId)
+                    .getUserStoreManager());
+        }
+        return userStoreManager;
     }
 
     public static Map<String, Object> getParamsFromProperties(final Map<String, Object> properties) {

--- a/src/main/java/org/sample/custom/audit/logger/utils/Utils.java
+++ b/src/main/java/org/sample/custom/audit/logger/utils/Utils.java
@@ -1,18 +1,12 @@
 package org.sample.custom.audit.logger.utils;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorStatus;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.model.User;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
-import org.wso2.carbon.identity.event.IdentityEventException;
-import org.wso2.carbon.user.api.UserStoreException;
-import org.wso2.carbon.user.core.UserCoreConstants;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,30 +16,6 @@ public final class Utils {
 
     private Utils() {
         // Prevent instantiation
-    }
-
-    public static String getUserStoreDomain(final org.wso2.carbon.user.api.UserStoreManager userStoreManager) {
-        if (userStoreManager instanceof org.wso2.carbon.user.core.UserStoreManager) {
-            final String domainNameProperty = ((org.wso2.carbon.user.core.UserStoreManager)userStoreManager)
-                    .getRealmConfiguration()
-                    .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
-            if (StringUtils.isBlank(domainNameProperty)) {
-                return IdentityUtil.getPrimaryDomainName();
-            } else {
-                return domainNameProperty;
-            }
-        } else {
-            return null;
-        }
-    }
-
-    public static String getTenantDomain(final org.wso2.carbon.user.api.UserStoreManager userStoreManager) throws IdentityEventException {
-        try {
-            return IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
-        } catch (UserStoreException e) {
-            log.error("Error while getting tenant domain for user store manager: " + userStoreManager, e);
-            return null;
-        }
     }
 
     public static Map<String, Object> getParamsFromProperties(final Map<String, Object> properties) {


### PR DESCRIPTION
This PR fixes an issue when retrieving user data from other tenants by retrieving the tenant's realm service, instead of the super tenant's realm service. The key change is to use `RealmService#getTenantUserRealm(int)` instead of `RealmService#getBootstrapRealm()`.